### PR TITLE
Refactor web test entrypoints to ESM modules

### DIFF
--- a/tests/js/bullet-reorder-fallback.test.js
+++ b/tests/js/bullet-reorder-fallback.test.js
@@ -10,12 +10,11 @@
  * as long as experience-details is available.
  */
 
-describe('showBulletReorder fallback behavior', () => {
-  let showBulletReorder
+import { showBulletReorder } from '../../web/workflow-steps.js'
 
+describe('showBulletReorder fallback behavior', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
-    vi.resetModules()
 
     // Minimal globals used by app.js during function execution.
     globalThis.window = globalThis.window || {}
@@ -36,9 +35,6 @@ describe('showBulletReorder fallback behavior', () => {
       CURRENT_TAB: 'cv-builder-current-tab',
       CHAT_COLLAPSED: 'cv-builder-chat-collapsed',
     }
-
-    const mod = require('../../web/app.js')
-    showBulletReorder = mod.showBulletReorder
   })
 
   afterEach(() => {

--- a/tests/js/post-analysis-questions.test.js
+++ b/tests/js/post-analysis-questions.test.js
@@ -4,30 +4,23 @@
 // This file is part of CV-Builder.
 // For commercial licensing, contact greg@warnes-innovations.com
 
+import { extractStructuredQuestionsFromAssistantText } from '../../web/job-analysis.js'
+
 /**
  * Regression tests for populating structured post-analysis questions from
  * assistant analysis text when the backend response lacks them.
  */
 
 describe('post-analysis question extraction', () => {
-  let app
   let originalFetch
 
-  function loadApp() {
-    delete require.cache[require.resolve('../../web/app.js')]
-    app = require('../../web/app.js')
-    return app
-  }
-
   beforeEach(() => {
-    vi.resetModules()
     window.history.replaceState({}, '', 'http://localhost/')
     sessionStorage.clear()
     originalFetch = globalThis.fetch
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
     window.fetch = fetchMock
-    loadApp()
   })
 
   afterEach(() => {
@@ -42,7 +35,7 @@ describe('post-analysis question extraction', () => {
   it('extracts numbered clarifying questions from assistant analysis text', () => {
     const text = `This is an exceptional match for your background.\n\nTo tailor your CV for Genentech, I have a few specific clarifying questions:\n\n1. Positioning - Architect vs. Maintainer: This role emphasizes sustained impact and mastery over new projects. Given your recent CTO and Chief Scientist roles, do you want to position yourself as the "Foundational Expert" or the "Hands-on Architect"?\n\n2. Specific Technical Evidence: The JD explicitly asks for experience with OAuth2/JWT authentication and Cloud Object Storage. Should I highlight those specific technical patterns and integrations?\n\n3. The "Complex Problem" Selection: The recruiter asked for a description of a complex technical problem solved in a production system. Would you prefer to highlight the MiDAS Genomic Workflow at Pfizer or a more recent platform modernization example?`
 
-    const questions = app.extractStructuredQuestionsFromAssistantText(text)
+    const questions = extractStructuredQuestionsFromAssistantText(text)
 
     expect(questions).toHaveLength(3)
     expect(questions.map(question => question.type)).toEqual([
@@ -57,7 +50,7 @@ describe('post-analysis question extraction', () => {
 
   it('returns no questions when the assistant text has no numbered list', () => {
     expect(
-      app.extractStructuredQuestionsFromAssistantText(
+      extractStructuredQuestionsFromAssistantText(
         'Analysis complete. Click Recommend Customizations when ready.'
       )
     ).toEqual([])

--- a/tests/js/session-switcher.test.js
+++ b/tests/js/session-switcher.test.js
@@ -11,23 +11,19 @@
  */
 
 import { formatSessionPhaseLabel } from '../../web/utils.js';
+import {
+  buildSessionSwitcherLabel,
+  getActiveSessionOwnershipMeta,
+} from '../../web/session-manager.js'
 
 describe('session switcher helpers', () => {
-  let app
   let originalFetch
 
-  function loadApp() {
-    app = require('../../web/app.js')
-    return app
-  }
-
   beforeEach(() => {
-    vi.resetModules()
     window.history.replaceState({}, '', 'http://localhost/')
     sessionStorage.clear()
     originalFetch = globalThis.fetch
     vi.stubGlobal('fetch', vi.fn())
-    loadApp()
   })
 
   afterEach(() => {
@@ -46,18 +42,18 @@ describe('session switcher helpers', () => {
   })
 
   it('builds a header label from position name and phase', () => {
-    expect(app.buildSessionSwitcherLabel({
+    expect(buildSessionSwitcherLabel({
       position_name: 'Senior Data Scientist',
       phase: 'generation',
     })).toBe('Senior Data Scientist · Generate')
   })
 
   it('falls back to the default sessions label when no session is active', () => {
-    expect(app.buildSessionSwitcherLabel({})).toBe('📂 Sessions')
+    expect(buildSessionSwitcherLabel({})).toBe('📂 Sessions')
   })
 
   it('marks the current session as owned by the current tab', () => {
-    const meta = app.getActiveSessionOwnershipMeta(
+    const meta = getActiveSessionOwnershipMeta(
       { session_id: 'sess-1', owned_by_requester: true, claimed: true },
       { currentSessionId: 'sess-1' },
     )
@@ -70,7 +66,7 @@ describe('session switcher helpers', () => {
   })
 
   it('marks foreign owned sessions distinctly', () => {
-    const meta = app.getActiveSessionOwnershipMeta(
+    const meta = getActiveSessionOwnershipMeta(
       { session_id: 'sess-2', owned_by_requester: false, claimed: true },
       { currentSessionId: 'sess-1' },
     )
@@ -83,7 +79,7 @@ describe('session switcher helpers', () => {
   })
 
   it('marks unclaimed sessions as available', () => {
-    const meta = app.getActiveSessionOwnershipMeta(
+    const meta = getActiveSessionOwnershipMeta(
       { session_id: 'sess-3', owned_by_requester: false, claimed: false },
       { currentSessionId: 'sess-1' },
     )

--- a/tests/js/state-manager.test.js
+++ b/tests/js/state-manager.test.js
@@ -37,12 +37,12 @@ const lsMock = createLocalStorageMock()
 let stateManager, initializeState, loadStateFromLocalStorage, saveStateToLocalStorage, clearState
 let StorageKeys
 
-beforeAll(() => {
+beforeAll(async () => {
   // Stub localStorage before any module code runs
   vi.stubGlobal('localStorage', lsMock)
 
   // 1. Load api-client exports and expose globals (mirrors browser load order)
-  const apiClient = require('../../web/api-client.js')
+  const apiClient = await import('../../web/api-client.js')
   StorageKeys = apiClient.StorageKeys
   globalThis.StorageKeys = StorageKeys
 
@@ -50,7 +50,7 @@ beforeAll(() => {
   globalThis.apiCall = vi.fn().mockResolvedValue({ messages: [], phase: 'init' })
 
   // 3. Now load state-manager (it references StorageKeys + apiCall at call time)
-  const sm = require('../../web/state-manager.js')
+  const sm = await import('../../web/state-manager.js')
   stateManager              = sm.stateManager
   initializeState           = sm.initializeState
   loadStateFromLocalStorage = sm.loadStateFromLocalStorage

--- a/tests/js/suggested-achievements.test.js
+++ b/tests/js/suggested-achievements.test.js
@@ -4,6 +4,12 @@
 // This file is part of CV-Builder.
 // For commercial licensing, contact greg@warnes-innovations.com
 
+import {
+  deleteSuggestedAchievement,
+  moveSuggestedAchievementRow,
+  saveSuggestedAchievementField,
+} from '../../web/achievements-review.js'
+
 /**
  * Unit tests for AI-suggested achievement helpers:
  *   saveSuggestedAchievementField
@@ -12,15 +18,8 @@
  *   _suggestedAchsOrdered reset on loadSessionFile
  */
 
-let saveSuggestedAchievementField, moveSuggestedAchievementRow, deleteSuggestedAchievement
-
 describe('suggested achievement helpers', () => {
   beforeEach(() => {
-    vi.resetModules()
-    const app = require('../../web/app.js')
-    saveSuggestedAchievementField = app.saveSuggestedAchievementField
-    moveSuggestedAchievementRow   = app.moveSuggestedAchievementRow
-    deleteSuggestedAchievement    = app.deleteSuggestedAchievement
     // Seed a small ordered list with stable IDs
     window._suggestedAchsOrdered = [
       { _suggId: 'sugg::0', title: 'Alpha', description: 'Desc A' },

--- a/web/app.js
+++ b/web/app.js
@@ -103,26 +103,4 @@ function setupEventListeners() {
   document.getElementById('reset-btn').addEventListener('click', resetSession);
 }
 
-// CJS export shim — no-op in browsers (module is undefined).
-// Re-exports from canonical module files so existing tests continue to pass.
-// NOTE: require() on ES-module files works only under Vitest's transform pipeline.
-//       Do not run these tests with plain Node.js (no bundler/transform).
-if (typeof module !== 'undefined') {
-  /* eslint-disable global-require */
-  const _sm  = require('./session-manager.js');
-  const _ja  = require('./job-analysis.js');
-  const _ach = require('./achievements-review.js');
-  const _ws  = require('./workflow-steps.js');
-  /* eslint-enable global-require */
-  module.exports = {
-    buildSessionSwitcherLabel:                   _sm.buildSessionSwitcherLabel,
-    getActiveSessionOwnershipMeta:               _sm.getActiveSessionOwnershipMeta,
-    extractStructuredQuestionsFromAssistantText: _ja.extractStructuredQuestionsFromAssistantText,
-    saveSuggestedAchievementField:               _ach.saveSuggestedAchievementField,
-    moveSuggestedAchievementRow:                 _ach.moveSuggestedAchievementRow,
-    deleteSuggestedAchievement:                  _ach.deleteSuggestedAchievement,
-    showBulletReorder:                           _ws.showBulletReorder,
-    init,
-    setupEventListeners,
-  };
-}
+// Tests now import helper functions from their canonical ES modules directly.

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/web/tests/integration/run_integration.js
+++ b/web/tests/integration/run_integration.js
@@ -5,10 +5,10 @@
 // This file is part of CV-Builder.
 // For commercial licensing, contact greg@warnes-innovations.com
 
-const http = require('http');
-const fs = require('fs');
-const path = require('path');
-const { chromium } = require('playwright');
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { chromium } from 'playwright';
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 8000;
 const ROOT = process.cwd();


### PR DESCRIPTION
## Summary
- add a web-scoped ESM package boundary for Node-based test and helper loading
- remove the CommonJS relay from `web/app.js` so tests import canonical modules directly
- align the integration runner and state-manager setup with ESM imports

## Why
This isolates the module-format cleanup to the `web/` subtree and removes the repo-side `MODULE_TYPELESS_PACKAGE_JSON` warning path without forcing a repo-wide package semantic change.

## Validation
- focused affected JS suites passed
- `npm run test:integration:headless` passed
- full JS suite passed: 37 files, 936 tests
