### PR TITLE
fix(security): address remaining CodeQL findings after PR #85

### DIFF
--- a/scripts/routes/master_data_routes.py
+++ b/scripts/routes/master_data_routes.py
@@ -1209,9 +1209,9 @@ def create_blueprint(deps):
 
         try:
             parsed = bibtex_text_to_publications(content)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning("BibTeX parse error in publications replace", exc_info=True)
-            return jsonify({"ok": False, "error": f"BibTeX parse error: {str(e)[:300]}"}), 400
+            return jsonify({"ok": False, "error": "BibTeX parse error in uploaded content."}), 400
 
         if content.strip() and not parsed:
             return jsonify({
@@ -1354,9 +1354,9 @@ def create_blueprint(deps):
 
         try:
             imported = bibtex_text_to_publications(bibtex_text)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning("BibTeX parse error in publications import", exc_info=True)
-            return jsonify({"ok": False, "error": f"BibTeX parse error: {str(e)[:300]}"}), 400
+            return jsonify({"ok": False, "error": "BibTeX parse error in submitted content."}), 400
 
         if not imported:
             return jsonify({"ok": False, "error": "No valid BibTeX entries found"}), 400

--- a/scripts/routes/session_routes.py
+++ b/scripts/routes/session_routes.py
@@ -51,12 +51,14 @@ def create_blueprint(deps):
         Always returns the fully-resolved path so that callers operate on a
         canonical, symlink-free path.
         """
-        candidate = Path(path_param)
+        raw = Path(path_param)
+        candidate = raw if raw.is_absolute() else session_root / raw
+        resolved_root = session_root.resolve()
         try:
             resolved = candidate.resolve()
-            resolved.relative_to(session_root.resolve())
+            resolved.relative_to(resolved_root)
             return resolved
-        except ValueError:
+        except (ValueError, OSError):
             return None
 
     @bp.post("/api/save")

--- a/scripts/routes/status_routes.py
+++ b/scripts/routes/status_routes.py
@@ -373,9 +373,9 @@ def create_blueprint(deps):
 
         try:
             validated_updates = _validate_settings_update(normalized_updates)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.exception("Settings validation failed")
-            return jsonify({'ok': False, 'error': str(exc)[:300]}), 400
+            return jsonify({'ok': False, 'error': 'Settings validation failed'}), 400
 
         config_path = _resolve_config_yaml_path()
         config_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
- session_routes: anchor relative paths to session_root before resolving; catch OSError alongside ValueError in path-traversal guard
- master_data_routes: replace bare exception messages with opaque strings for BibTeX parse errors (replace and import routes)
- status_routes: replace bare exception message with opaque string for settings validation failure

Fixes CodeQL alerts: uncontrolled data in path expression (HIGH), information exposure through exception (MEDIUM x3).