### PR TITLE
fix(obo): use the oboe_sessions name the tooling actually reads

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -55,7 +55,7 @@ follow its instructions.
 ## /obo session management
 
 Helper: `/Users/warnes/src/vscode-config/.github/skills/one-by-one/obo_helper.py`
-Session dir: `.github/obo_sessions/`
+Session dir: `.github/oboe_sessions/`
 
 Always check for existing sessions before starting a new one:
 ```bash

--- a/.clinerules
+++ b/.clinerules
@@ -89,7 +89,7 @@ When the user invokes a slash command, read the corresponding `.prompt.md` file.
 ## MCP Tools available in Cline
 
 - Prefer the 'oboe-mcp' MCP tools for OBO session state.
-- Do not edit .github/obo_sessions/*.json directly or use 'obo_helper.py' when 'oboe-mcp' can perform the operation. Fall back to 'oboe-cli' when the MCP server is unavailable.
+- Do not edit .github/oboe_sessions/*.json directly or use 'obo_helper.py' when 'oboe-mcp' can perform the operation. Fall back to 'oboe-cli' when the MCP server is unavailable.
 - **oboe-mcp**: `obo_list_sessions`, `obo_create`, `obo_session_status`, `obo_next`, `obo_list_items`, `obo_get_item`, `obo_mark_blocked`, `obo_mark_complete`, `obo_mark_in_progress`, `obo_mark_skip`, `obo_set_approval`, `obo_complete_session`, `obo_create_child_session`, `obo_complete_child_session`, `obo_merge_items`, `obo_update_field`
 - **oboe-cli fallback** (when MCP unavailable): all session-scoped commands take `--session SESSION [--base-dir DIR]`
   - sessions/status/next/complete-session/list/show/in-progress/block/complete/skip/approve/update/merge/create-child/complete-child

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -172,7 +172,7 @@ Slash commands are available from the shared prompt set in `~/src/agent-config/.
 
 ### /obo in cv-builder
 
-- Session dir: `.github/obo_sessions/`
+- Session dir: `.github/oboe_sessions/`
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,21 @@ archive/
 
 # OS artifacts
 .DS_Store
+
+# OBO session state — work-in-progress notes, not repo content, and THIS REPO IS
+# PUBLIC. A session records whatever task is in flight, including the commands to
+# run it, so nobody chooses in advance what a future one will contain.
+#
+# `oboe_sessions` is the name the tooling reads (oboe-mcp hardcodes
+# .github/oboe_sessions and no flag selects another); `obo_sessions` is the
+# pre-rename name. Both names are listed in both forms: a trailing slash restricts
+# a pattern to DIRECTORIES and git does not treat a symlink as one, so the slash
+# form alone stops matching the moment the directory becomes a symlink into the
+# canonical store. Before this, only the legacy slash form was listed — which left
+# the one name a working setup must use as the one name NOT ignored.
+.github/oboe_sessions
+.github/oboe_sessions/
+.github/obo_sessions
 .github/obo_sessions/
 
 # Personal configuration (contains local paths and API keys — not for sharing)

--- a/codex-skills/one-by-one-codex/SKILL.md
+++ b/codex-skills/one-by-one-codex/SKILL.md
@@ -14,11 +14,11 @@ Adapted from:
 
 - The user asks for `/obo`, one-by-one processing, or sequential review
 - A list of findings, tasks, or design decisions should be handled one at a time
-- You need resumable session state in `.github/obo_sessions/`
+- You need resumable session state in `.github/oboe_sessions/`
 
 ## Session handling
 
-- Session files live in `.github/obo_sessions/`
+- Session files live in `.github/oboe_sessions/`
 - Prefer the helper script if available:
   `/Users/warnes/src/agent-config/skills/one-by-one/obo_helper.py`
 - If MCP/session helpers are unavailable, manage the JSON files directly


### PR DESCRIPTION
## Summary

Every OBO path in this repo pointed at `.github/obo_sessions/`, the pre-rename name. `oboe-mcp` reads `base_dir/.github/oboe_sessions` and nothing else — `session.py` hardcodes it, and `--base-dir` names the project root rather than the session directory, so no flag or environment variable selects another name. The `.gitignore` half of that is a latent disclosure gap in a **public** repo.

## Changes

- **`.gitignore`** — the part that matters. It listed only `.github/obo_sessions/`, so the one name a working setup must use was the one name **not** ignored: creating the correctly-named link, which the corrected instructions below now tell you to do, would have left session files one `git add -A` from being committed to a public repository. An OBO session records whatever task is in flight including the commands to run it, so nobody chooses in advance what a future one contains. All four forms are now listed (both names × both slash forms) — a trailing slash restricts a pattern to *directories* and git does not treat a symlink as one
- **`.clinerules`** — both occurrences (`Session dir:` and the managed MCP-tools block)
- **`.github/copilot-instructions.md`** — session dir
- **`codex-skills/one-by-one-codex/SKILL.md`** — both occurrences

**Nothing has been disclosed.** Verified against the full tree that this repo tracks zero session files under either name. This closes a latent gap, not an open one.

Left alone deliberately: the `tasks/*.md` records citing specific past session files by their old paths. Those are historical notes, not configuration.

## Testing

- [x] `git check-ignore --no-index -v` from inside the repo: all four forms match, and a negative control (`.github/other_sessions`) does **not** — so the check is capable of failing
- ~~All Python tests pass~~ — no Python changed
- ~~All JS tests pass~~ — no JS changed
- ~~JS bundle rebuilt~~ — no JS/CSS changed
- ~~No duplicate helper definitions~~ — no helpers changed

## Data-contract checklist

~~Not applicable — this PR does not change the structure of `Master_CV_Data.json`.~~

## Related gaps / issues

Found by an org-wide sweep of all 59 Warnes-Innovations repositories for the obsolete path name.

---
_Generated by [Claude Code](https://claude.ai/code/session_014mj7YmAEv8iF9ivr9EMXLo)_